### PR TITLE
Add grid layout for button demos

### DIFF
--- a/prime.html
+++ b/prime.html
@@ -6,6 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://unpkg.com/primereact/resources/themes/saga-blue/theme.css">
+  <link rel="stylesheet" href="https://unpkg.com/primereact/resources/primereact.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/primeicons/primeicons.css">
   <style>
     body { margin: 0; font-family: 'Segoe UI', sans-serif; overflow: hidden; }
     .view-selector { display: flex; height: 100vh; }
@@ -82,12 +85,21 @@
       user-select: none;
     }
     .canvas-icon, .components-icon {
-      position: absolute;
+      position: fixed;
       top: 10px;
       right: 10px;
       font-size: 24px;
       cursor: pointer;
       z-index: 9999;
+    }
+    .sections-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+    .sections-grid .section {
+      flex: 1 1 300px;
     }
     .draggable-component { cursor: grab; display: inline-block; margin: 0.25rem; }
     .export-button {
@@ -135,6 +147,131 @@
       <div class="draggable-component" draggable="true" data-html='<button class="btn btn-danger">Danger</button>'><button class="btn btn-danger">Danger</button></div>
       <div class="draggable-component" draggable="true" data-html='<input type="text" class="form-control" placeholder="Unesi tekst">'><input type="text" class="form-control" placeholder="Unesi tekst" style="width: 200px;"></div>
     </div>
+
+    <div class="sections-grid">
+    <div class="section">
+      <h5>Default</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-primary">Primary</button>
+        <button class="p-button p-button-secondary">Secondary</button>
+        <button class="p-button p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Icons</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-primary"><span class="pi pi-check p-button-icon p-button-icon-left"></span><span class="p-button-label">Check</span></button>
+        <button class="p-button p-button-secondary"><span class="pi pi-bookmark p-button-icon p-button-icon-left"></span><span class="p-button-label">Bookmark</span></button>
+        <button class="p-button p-button-help"><span class="pi pi-search p-button-icon p-button-icon-left"></span><span class="p-button-label">Search</span></button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Severities</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-secondary">Secondary</button>
+        <button class="p-button p-button-success">Success</button>
+        <button class="p-button p-button-info">Info</button>
+        <button class="p-button p-button-warning">Warning</button>
+        <button class="p-button p-button-danger">Danger</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Raised</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-raised p-button-primary">Primary</button>
+        <button class="p-button p-button-raised p-button-secondary">Secondary</button>
+        <button class="p-button p-button-raised p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Rounded</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-rounded p-button-primary">Primary</button>
+        <button class="p-button p-button-rounded p-button-secondary">Secondary</button>
+        <button class="p-button p-button-rounded p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Text</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-text p-button-primary">Primary</button>
+        <button class="p-button p-button-text p-button-secondary">Secondary</button>
+        <button class="p-button p-button-text p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Rounded Icons</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-rounded p-button-primary p-button-icon-only"><span class="pi pi-check"></span></button>
+        <button class="p-button p-button-rounded p-button-warning p-button-icon-only"><span class="pi pi-star"></span></button>
+        <button class="p-button p-button-rounded p-button-danger p-button-icon-only"><span class="pi pi-heart"></span></button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Outlined</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-outlined p-button-primary">Primary</button>
+        <button class="p-button p-button-outlined p-button-secondary">Secondary</button>
+        <button class="p-button p-button-outlined p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Rounded Text</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-rounded p-button-text p-button-primary">Primary</button>
+        <button class="p-button p-button-rounded p-button-text p-button-secondary">Secondary</button>
+        <button class="p-button p-button-rounded p-button-text p-button-success">Success</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Button Group</h5>
+      <div class="p-buttonset">
+        <button class="p-button p-button-primary">Save</button>
+        <button class="p-button p-button-primary">Delete</button>
+        <button class="p-button p-button-primary">Cancel</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Loading</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-primary p-button-loading">
+          <span class="p-button-label">Loading</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Split Button</h5>
+      <div class="p-splitbutton p-component">
+        <button class="p-button p-button-primary">Save</button>
+        <button class="p-button p-button-primary p-button-icon-only"><span class="pi pi-chevron-down"></span></button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h5>Template</h5>
+      <div class="btn-group-wrap">
+        <button class="p-button p-button-success">
+          <span class="pi pi-check p-button-icon p-button-icon-left"></span>
+          <span class="p-button-label">Custom</span>
+        </button>
+        <button class="p-button p-button-warning">
+          <span class="pi pi-star p-button-icon p-button-icon-left"></span>
+          <span class="p-button-label">Star</span>
+        </button>
+      </div>
+    </div>
+    </div> <!-- end sections-grid -->
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- keep canvas buttons visible while scrolling
- display button examples in a flexible grid

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b6a7fadc88325b0f0787a2f45d49c