### PR TITLE
Add standalone inputs page

### DIFF
--- a/inputs.html
+++ b/inputs.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>PrimeReact Buttons</title>
+  <title>PrimeReact Inputs</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -125,9 +125,9 @@
   <div class="sidebar">
     <h6>UI COMPONENTS</h6>
     <nav class="nav flex-column">
-      <a class="nav-link active" href="prime.html">Button</a>
+      <a class="nav-link" href="prime.html">Button</a>
       <a class="nav-link" href="#">Form Layout</a>
-      <a class="nav-link" href="inputs.html">Input</a>
+      <a class="nav-link active" href="inputs.html">Input</a>
       <a class="nav-link" href="#">Float Label</a>
       <a class="nav-link" href="#">Invalid State</a>
       <a class="nav-link" href="#">Dashboard</a>
@@ -152,138 +152,48 @@
   <div class="main-content">
     <div class="canvas-icon" id="canvas-icon">🖼</div>
 
-    <div class="section">
-      <h5>Drag & Drop Dugmad</h5>
-      <div class="draggable-component" draggable="true" data-html='<button class="btn btn-primary">Primary</button>'><button class="btn btn-primary">Primary</button></div>
-      <div class="draggable-component" draggable="true" data-html='<button class="btn btn-danger">Danger</button>'><button class="btn btn-danger">Danger</button></div>
-      <div class="draggable-component" draggable="true" data-html='<input type="text" class="form-control" placeholder="Unesi tekst">'><input type="text" class="form-control" placeholder="Unesi tekst" style="width: 200px;"></div>
-    </div>
 
+    <h4>Inputs</h4>
     <div class="sections-grid">
-    <div class="section">
-      <h5>Default</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-success draggable-component" draggable="true">Success</button>
+      <div class="section">
+        <h5>Basic</h5>
+        <div class="btn-group-wrap">
+          <input type="text" class="p-inputtext draggable-component" draggable="true" placeholder="Text" style="width: 150px;">
+          <input type="password" class="p-inputtext draggable-component" draggable="true" placeholder="Password" style="width: 150px;">
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <h5>Icons</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-primary draggable-component" draggable="true"><span class="pi pi-check p-button-icon p-button-icon-left"></span><span class="p-button-label">Check</span></button>
-        <button class="p-button p-button-secondary draggable-component" draggable="true"><span class="pi pi-bookmark p-button-icon p-button-icon-left"></span><span class="p-button-label">Bookmark</span></button>
-        <button class="p-button p-button-help draggable-component" draggable="true"><span class="pi pi-search p-button-icon p-button-icon-left"></span><span class="p-button-label">Search</span></button>
+      <div class="section">
+        <h5>Icons</h5>
+        <div class="btn-group-wrap">
+          <span class="p-input-icon-left draggable-component" draggable="true">
+            <i class="pi pi-search"></i>
+            <input type="text" class="p-inputtext" placeholder="Search" style="width: 150px;">
+          </span>
+          <span class="p-input-icon-right draggable-component" draggable="true">
+            <input type="text" class="p-inputtext" placeholder="Filter" style="width: 150px;">
+            <i class="pi pi-filter"></i>
+          </span>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <h5>Severities</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-success draggable-component" draggable="true">Success</button>
-        <button class="p-button p-button-info draggable-component" draggable="true">Info</button>
-        <button class="p-button p-button-warning draggable-component" draggable="true">Warning</button>
-        <button class="p-button p-button-danger draggable-component" draggable="true">Danger</button>
+      <div class="section">
+        <h5>Text Area</h5>
+        <div class="btn-group-wrap">
+          <textarea class="p-inputtextarea draggable-component" draggable="true" rows="3" cols="30" placeholder="Your message"></textarea>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <h5>Raised</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-raised p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-raised p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-raised p-button-success draggable-component" draggable="true">Success</button>
+      <div class="section">
+        <h5>Input Group</h5>
+        <div class="btn-group-wrap">
+          <div class="p-inputgroup draggable-component" draggable="true">
+            <span class="p-inputgroup-addon">@</span>
+            <input type="text" class="p-inputtext" placeholder="Username" style="width: 150px;">
+          </div>
+        </div>
       </div>
-    </div>
-
-    <div class="section">
-      <h5>Rounded</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-rounded p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-rounded p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-rounded p-button-success draggable-component" draggable="true">Success</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Text</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-text p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-text p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-text p-button-success draggable-component" draggable="true">Success</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Rounded Icons</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-rounded p-button-primary p-button-icon-only draggable-component" draggable="true"><span class="pi pi-check"></span></button>
-        <button class="p-button p-button-rounded p-button-warning p-button-icon-only draggable-component" draggable="true"><span class="pi pi-star"></span></button>
-        <button class="p-button p-button-rounded p-button-danger p-button-icon-only draggable-component" draggable="true"><span class="pi pi-heart"></span></button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Outlined</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-outlined p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-outlined p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-outlined p-button-success draggable-component" draggable="true">Success</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Rounded Text</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-rounded p-button-text p-button-primary draggable-component" draggable="true">Primary</button>
-        <button class="p-button p-button-rounded p-button-text p-button-secondary draggable-component" draggable="true">Secondary</button>
-        <button class="p-button p-button-rounded p-button-text p-button-success draggable-component" draggable="true">Success</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Button Group</h5>
-      <div class="p-buttonset">
-        <button class="p-button p-button-primary draggable-component" draggable="true">Save</button>
-        <button class="p-button p-button-primary draggable-component" draggable="true">Delete</button>
-        <button class="p-button p-button-primary draggable-component" draggable="true">Cancel</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Loading</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-primary p-button-loading draggable-component" draggable="true">
-          <span class="p-button-label">Loading</span>
-        </button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Split Button</h5>
-      <div class="p-splitbutton p-component draggable-component" draggable="true">
-        <button class="p-button p-button-primary">Save</button>
-        <button class="p-button p-button-primary p-button-icon-only"><span class="pi pi-chevron-down"></span></button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h5>Template</h5>
-      <div class="btn-group-wrap">
-        <button class="p-button p-button-success draggable-component" draggable="true">
-          <span class="pi pi-check p-button-icon p-button-icon-left"></span>
-          <span class="p-button-label">Custom</span>
-        </button>
-        <button class="p-button p-button-warning draggable-component" draggable="true">
-          <span class="pi pi-star p-button-icon p-button-icon-left"></span>
-          <span class="p-button-label">Star</span>
-        </button>
-      </div>
-    </div>
-    </div> <!-- end sections-grid -->
-
+    </div> <!-- end inputs sections-grid -->
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- route buttons and inputs through the sidebar
- move PrimeReact input examples to their own page

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf8ba28508325ae72023bc113c097