### PR TITLE
Enable resizing of canvas components

### DIFF
--- a/inputs.html
+++ b/inputs.html
@@ -85,6 +85,16 @@
       position: absolute;
       cursor: move;
       user-select: none;
+      display: inline-block;
+    }
+    .resize-handle {
+      width: 10px;
+      height: 10px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      background: #666;
+      cursor: se-resize;
     }
 
     .canvas-icon, .components-icon {
@@ -249,7 +259,11 @@
     wrapper.style.left = x + 'px';
     wrapper.style.top = y + 'px';
     dropZone.appendChild(wrapper);
+    const rect = wrapper.getBoundingClientRect();
+    wrapper.style.width = rect.width + 'px';
+    wrapper.style.height = rect.height + 'px';
     makeDraggable(wrapper);
+    makeResizable(wrapper);
   }
 
   function openCanvas() {
@@ -261,6 +275,7 @@
     let isDragging = false;
     let offsetX, offsetY;
     el.addEventListener("mousedown", function (e) {
+      if (e.target.classList.contains("resize-handle")) return;
       isDragging = true;
       offsetX = e.clientX - el.offsetLeft;
       offsetY = e.clientY - el.offsetTop;
@@ -278,6 +293,34 @@
     });
   }
 
+  function makeResizable(el) {
+    const handle = document.createElement("div");
+    handle.classList.add("resize-handle");
+    el.appendChild(handle);
+
+    let isResizing = false;
+    let startX, startY, startWidth, startHeight;
+
+    handle.addEventListener("mousedown", function(e) {
+      e.stopPropagation();
+      isResizing = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      startWidth = parseInt(document.defaultView.getComputedStyle(el).width, 10);
+      startHeight = parseInt(document.defaultView.getComputedStyle(el).height, 10);
+    });
+
+    document.addEventListener("mousemove", function(e) {
+      if (!isResizing) return;
+      el.style.width = (startWidth + e.clientX - startX) + "px";
+      el.style.height = (startHeight + e.clientY - startY) + "px";
+    });
+
+    document.addEventListener("mouseup", function() {
+      isResizing = false;
+    });
+  }
+
   function resetCanvas() {
     dropZone.innerHTML = "";
   }
@@ -287,7 +330,7 @@
     let content = "";
     components.forEach(el => {
       const html = el.innerHTML;
-      const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top};\"`;
+      const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
       content += `<div ${style}>${html}</div>\n`;
     });
 

--- a/prime.html
+++ b/prime.html
@@ -87,6 +87,16 @@
       position: absolute;
       cursor: move;
       user-select: none;
+      display: inline-block;
+    }
+    .resize-handle {
+      width: 10px;
+      height: 10px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      background: #666;
+      cursor: se-resize;
     }
 
     .canvas-icon, .components-icon {
@@ -409,7 +419,11 @@
     wrapper.style.left = x + 'px';
     wrapper.style.top = y + 'px';
     dropZone.appendChild(wrapper);
+    const rect = wrapper.getBoundingClientRect();
+    wrapper.style.width = rect.width + 'px';
+    wrapper.style.height = rect.height + 'px';
     makeDraggable(wrapper);
+    makeResizable(wrapper);
   }
 
   function openCanvas() {
@@ -421,6 +435,7 @@
     let isDragging = false;
     let offsetX, offsetY;
     el.addEventListener("mousedown", function (e) {
+      if (e.target.classList.contains("resize-handle")) return;
       isDragging = true;
       offsetX = e.clientX - el.offsetLeft;
       offsetY = e.clientY - el.offsetTop;
@@ -438,6 +453,34 @@
     });
   }
 
+  function makeResizable(el) {
+    const handle = document.createElement("div");
+    handle.classList.add("resize-handle");
+    el.appendChild(handle);
+
+    let isResizing = false;
+    let startX, startY, startWidth, startHeight;
+
+    handle.addEventListener("mousedown", function(e) {
+      e.stopPropagation();
+      isResizing = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      startWidth = parseInt(document.defaultView.getComputedStyle(el).width, 10);
+      startHeight = parseInt(document.defaultView.getComputedStyle(el).height, 10);
+    });
+
+    document.addEventListener("mousemove", function(e) {
+      if (!isResizing) return;
+      el.style.width = (startWidth + e.clientX - startX) + "px";
+      el.style.height = (startHeight + e.clientY - startY) + "px";
+    });
+
+    document.addEventListener("mouseup", function() {
+      isResizing = false;
+    });
+  }
+
   function resetCanvas() {
     dropZone.innerHTML = "";
   }
@@ -447,7 +490,7 @@
     let content = "";
     components.forEach(el => {
       const html = el.innerHTML;
-      const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top};\"`;
+      const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
       content += `<div ${style}>${html}</div>\n`;
     });
 


### PR DESCRIPTION
## Summary
- allow canvas components to be resized with a drag handle
- preserve width and height on export

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c10508d248325b34971e668be219c