### PR TITLE
Add draggable table examples

### DIFF
--- a/prime.html
+++ b/prime.html
@@ -139,7 +139,7 @@
       <a class="nav-link" href="#">Float Label</a>
       <a class="nav-link" href="#">Invalid State</a>
       <a class="nav-link" href="#">Dashboard</a>
-      <a class="nav-link" href="#">Table</a>
+      <a class="nav-link" href="#" data-target="table-section">Table</a>
       <a class="nav-link" href="#">List</a>
       <a class="nav-link" href="#">Tree</a>
       <a class="nav-link" href="#">Panel</a>
@@ -337,6 +337,84 @@
         </div>
       </div> <!-- end inputs sections-grid -->
     </div> <!-- end inputs-section -->
+
+    <div id="table-section" class="main-section" style="display:none;">
+      <h4>Tables</h4>
+      <div class="sections-grid">
+        <div class="section">
+          <h5>Basic</h5>
+          <div class="draggable-component" draggable="true">
+            <div class="p-datatable p-component">
+              <div class="p-datatable-wrapper">
+                <table class="p-datatable-table" role="grid">
+                  <thead class="p-datatable-thead">
+                    <tr>
+                      <th>Name</th>
+                      <th>Age</th>
+                      <th>Country</th>
+                    </tr>
+                  </thead>
+                  <tbody class="p-datatable-tbody">
+                    <tr><td>John</td><td>30</td><td>USA</td></tr>
+                    <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                    <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h5>Striped</h5>
+          <div class="draggable-component" draggable="true">
+            <div class="p-datatable p-component p-datatable-striped">
+              <div class="p-datatable-wrapper">
+                <table class="p-datatable-table" role="grid">
+                  <thead class="p-datatable-thead">
+                    <tr>
+                      <th>Name</th>
+                      <th>Age</th>
+                      <th>Country</th>
+                    </tr>
+                  </thead>
+                  <tbody class="p-datatable-tbody">
+                    <tr><td>John</td><td>30</td><td>USA</td></tr>
+                    <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                    <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h5>Gridlines</h5>
+          <div class="draggable-component" draggable="true">
+            <div class="p-datatable p-component p-datatable-gridlines">
+              <div class="p-datatable-wrapper">
+                <table class="p-datatable-table" role="grid">
+                  <thead class="p-datatable-thead">
+                    <tr>
+                      <th>Name</th>
+                      <th>Age</th>
+                      <th>Country</th>
+                    </tr>
+                  </thead>
+                  <tbody class="p-datatable-tbody">
+                    <tr><td>John</td><td>30</td><td>USA</td></tr>
+                    <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                    <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div> <!-- end table sections-grid -->
+    </div> <!-- end table-section -->
 
   </div> <!-- end main-content -->
 </div> <!-- end component-view -->

--- a/tables.html
+++ b/tables.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PrimeReact Tables</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://unpkg.com/primereact/resources/themes/saga-blue/theme.css">
+  <link rel="stylesheet" href="https://unpkg.com/primereact/resources/primereact.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/primeicons/primeicons.css">
+
+  <style>
+    body { margin: 0; font-family: 'Segoe UI', sans-serif; overflow: hidden; }
+    .view-selector { display: flex; height: 100vh; }
+    .sidebar {
+      width: 320px;
+      background: #ffffff;
+      border-right: 1px solid #ddd;
+      padding: 1rem 0.5rem;
+      overflow-y: auto;
+    }
+    .sidebar h6 {
+      font-weight: bold;
+      font-size: 0.75rem;
+      color: #333;
+      text-transform: uppercase;
+      margin: 1rem 0 0.5rem 1rem;
+    }
+    .sidebar .nav-link {
+      padding: 0.5rem 1rem;
+      color: #333;
+      border-radius: 4px;
+      font-size: 0.95rem;
+    }
+    .sidebar .nav-link:hover,
+    .sidebar .nav-link.active {
+      background-color: #eaf3ff;
+      color: #007bff;
+    }
+    .main-content {
+      flex-grow: 1;
+      padding: 2rem;
+      background-color: #f9f9f9;
+      overflow-y: auto;
+      position: relative;
+    }
+    .section {
+      margin-bottom: 2.5rem;
+      background: #fff;
+      padding: 1rem;
+      border-radius: 8px;
+      box-shadow: 0 0 5px rgba(0,0,0,0.05);
+    }
+    .section h5 {
+      font-weight: bold;
+      margin-bottom: 1rem;
+    }
+    .btn-group-wrap {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .canvas-view {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: white;
+      z-index: 999;
+    }
+    .canvas {
+      width: 100%;
+      height: 100%;
+      position: relative;
+      overflow: hidden;
+      background-image: linear-gradient(to right, rgba(0,0,0,0.05) 1px, transparent 1px),
+                        linear-gradient(to bottom, rgba(0,0,0,0.05) 1px, transparent 1px);
+      background-size: calc(100% / 12) 40px;
+    }
+
+    .canvas-component {
+      position: absolute;
+      cursor: move;
+      user-select: none;
+      display: inline-block;
+      box-sizing: border-box;
+    }
+
+
+    .canvas-icon, .components-icon {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      font-size: 24px;
+      cursor: pointer;
+      z-index: 9999;
+    }
+    .sections-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+    .sections-grid .section {
+      flex: 1 1 300px;
+    }
+
+    .draggable-component { cursor: grab; display: inline-block; margin: 0.25rem; }
+    .export-button {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      z-index: 10000;
+    }
+    .reset-button {
+      position: absolute;
+      bottom: 10px;
+      left: 10px;
+      z-index: 10000;
+    }
+  </style>
+</head>
+<body>
+<div class="view-selector" id="component-view">
+  <div class="sidebar">
+    <h6>UI COMPONENTS</h6>
+    <nav class="nav flex-column">
+      <a class="nav-link" href="prime.html">Button</a>
+      <a class="nav-link" href="#">Form Layout</a>
+      <a class="nav-link" href="inputs.html">Input</a>
+      <a class="nav-link" href="#">Float Label</a>
+      <a class="nav-link" href="#">Invalid State</a>
+      <a class="nav-link" href="#">Dashboard</a>
+      <a class="nav-link active" href="tables.html">Table</a>
+      <a class="nav-link" href="#">List</a>
+      <a class="nav-link" href="#">Tree</a>
+      <a class="nav-link" href="#">Panel</a>
+      <a class="nav-link" href="#">Overlay</a>
+      <a class="nav-link" href="#">Media</a>
+      <a class="nav-link" href="#">Menu</a>
+      <a class="nav-link" href="#">Message</a>
+      <a class="nav-link" href="#">File</a>
+      <a class="nav-link" href="#">Chart</a>
+      <a class="nav-link" href="#">Misc</a>
+    </nav>
+    <h6 class="mt-3">PRIME BLOCKS</h6>
+    <nav class="nav flex-column">
+      <a class="nav-link" href="#">Free Blocks</a>
+      <a class="nav-link" href="#">All Blocks</a>
+    </nav>
+  </div>
+  <div class="main-content">
+    <div class="canvas-icon" id="canvas-icon">🖼</div>
+
+    <h4>Tables</h4>
+    <div class="sections-grid">
+      <div class="section">
+        <h5>Basic</h5>
+        <div class="draggable-component" draggable="true">
+          <div class="p-datatable p-component">
+            <div class="p-datatable-wrapper">
+              <table class="p-datatable-table" role="grid">
+                <thead class="p-datatable-thead">
+                  <tr>
+                    <th>Name</th>
+                    <th>Age</th>
+                    <th>Country</th>
+                  </tr>
+                </thead>
+                <tbody class="p-datatable-tbody">
+                  <tr><td>John</td><td>30</td><td>USA</td></tr>
+                  <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                  <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="section">
+        <h5>Striped</h5>
+        <div class="draggable-component" draggable="true">
+          <div class="p-datatable p-component p-datatable-striped">
+            <div class="p-datatable-wrapper">
+              <table class="p-datatable-table" role="grid">
+                <thead class="p-datatable-thead">
+                  <tr>
+                    <th>Name</th>
+                    <th>Age</th>
+                    <th>Country</th>
+                  </tr>
+                </thead>
+                <tbody class="p-datatable-tbody">
+                  <tr><td>John</td><td>30</td><td>USA</td></tr>
+                  <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                  <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="section">
+        <h5>Gridlines</h5>
+        <div class="draggable-component" draggable="true">
+          <div class="p-datatable p-component p-datatable-gridlines">
+            <div class="p-datatable-wrapper">
+              <table class="p-datatable-table" role="grid">
+                <thead class="p-datatable-thead">
+                  <tr>
+                    <th>Name</th>
+                    <th>Age</th>
+                    <th>Country</th>
+                  </tr>
+                </thead>
+                <tbody class="p-datatable-tbody">
+                  <tr><td>John</td><td>30</td><td>USA</td></tr>
+                  <tr><td>Ana</td><td>28</td><td>Spain</td></tr>
+                  <tr><td>Lee</td><td>32</td><td>South Korea</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div> <!-- end table sections-grid -->
+  </div>
+</div>
+
+
+
+<div class="canvas-view" id="canvas-view">
+  <div class="canvas" id="drop-zone"></div>
+  <div class="components-icon" id="components-icon">📦</div>
+  <button class="btn btn-danger reset-button" onclick="resetCanvas()">Reset</button>
+  <button class="btn btn-success export-button" onclick="exportCanvas()">Export HTML</button>
+</div>
+
+<script>
+  let draggedHTML = "";
+  const dropZone = document.getElementById("drop-zone");
+  const canvasView = document.getElementById("canvas-view");
+  const componentView = document.getElementById("component-view");
+  const canvasIcon = document.getElementById("canvas-icon");
+  const componentsIcon = document.getElementById("components-icon");
+
+
+  document.querySelectorAll(".draggable-component").forEach(el => {
+    el.addEventListener("dragstart", e => {
+      draggedHTML = e.target.getAttribute("data-html") || e.target.outerHTML;
+    });
+  });
+
+
+  document.addEventListener("dragover", e => e.preventDefault());
+  canvasIcon.addEventListener("drop", e => {
+    e.preventDefault();
+    openCanvas();
+    setTimeout(() => dropComponentToCanvas(100, 100), 100);
+  });
+  canvasIcon.addEventListener("click", openCanvas);
+  componentsIcon.addEventListener("click", () => {
+    canvasView.style.display = "none";
+    componentView.style.display = "flex";
+  });
+  dropZone.addEventListener("drop", e => {
+    e.preventDefault();
+    dropComponentToCanvas(e.offsetX, e.offsetY);
+  });
+
+
+  function dropComponentToCanvas(x, y) {
+    if (!draggedHTML) return;
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("canvas-component");
+    wrapper.innerHTML = draggedHTML;
+    wrapper.removeAttribute("draggable");
+    wrapper.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    wrapper.addEventListener('dragstart', e => e.preventDefault());
+    wrapper.style.left = x + 'px';
+    wrapper.style.top = y + 'px';
+    dropZone.appendChild(wrapper);
+    const rect = wrapper.getBoundingClientRect();
+    wrapper.style.width = rect.width + 'px';
+    wrapper.style.height = rect.height + 'px';
+    makeDraggable(wrapper);
+  }
+
+
+  function openCanvas() {
+    componentView.style.display = "none";
+    canvasView.style.display = "block";
+  }
+
+
+  function makeDraggable(el) {
+    let isDragging = false;
+    let isResizing = false;
+    let offsetX, offsetY;
+    let startX, startY, startW, startH;
+
+    el.addEventListener("mousedown", function (e) {
+      const rect = el.getBoundingClientRect();
+      const nearRight = rect.right - e.clientX < 10;
+      const nearBottom = rect.bottom - e.clientY < 10;
+      if (nearRight || nearBottom) {
+        isResizing = true;
+        startX = e.clientX;
+        startY = e.clientY;
+        startW = rect.width;
+        startH = rect.height;
+        e.preventDefault();
+        return;
+      }
+      isDragging = true;
+      offsetX = e.clientX - el.offsetLeft;
+      offsetY = e.clientY - el.offsetTop;
+      el.style.zIndex = "1000";
+    });
+
+    document.addEventListener("mousemove", function (e) {
+      if (isDragging) {
+        el.style.left = (e.clientX - offsetX) + "px";
+        el.style.top = (e.clientY - offsetY) + "px";
+      } else if (isResizing) {
+        el.style.width = (startW + (e.clientX - startX)) + "px";
+        el.style.height = (startH + (e.clientY - startY)) + "px";
+      }
+    });
+
+    document.addEventListener("mouseup", function () {
+      isDragging = false;
+      isResizing = false;
+      el.style.zIndex = "1";
+    });
+  }
+
+
+  function resetCanvas() {
+    dropZone.innerHTML = "";
+  }
+
+  function exportCanvas() {
+    const components = dropZone.querySelectorAll(".canvas-component");
+    let content = "";
+    components.forEach(el => {
+      const html = el.innerHTML;
+      const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
+      content += `<div ${style}>${html}</div>\n`;
+    });
+
+
+    const fullHtml = `<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\">
+<title>Exported Page</title>
+<link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css\">
+<link rel=\"stylesheet\" href=\"https://unpkg.com/primereact/resources/themes/saga-blue/theme.css\">
+<link rel=\"stylesheet\" href=\"https://unpkg.com/primereact/resources/primereact.min.css\">
+<link rel=\"stylesheet\" href=\"https://unpkg.com/primeicons/primeicons.css\">
+<style>body { margin:0; padding:0; }</style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
+
+    const blob = new Blob([fullHtml], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "exported-page.html";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `table-section` with three draggable PrimeReact tables
- link the Table section in the sidebar
- create a dedicated `tables.html` page with table examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c35a215ec8325a547ac74edf11303