### PR TITLE
Add resize handles for canvas components

### DIFF
--- a/inputs.html
+++ b/inputs.html
@@ -88,8 +88,24 @@
       user-select: none;
       display: inline-block;
       box-sizing: border-box;
+      border: 1px dashed transparent;
     }
-
+    .canvas-component:hover {
+      border-color: #6c757d;
+    }
+    .resize-handle {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 10px;
+      height: 10px;
+      background: #007bff;
+      cursor: se-resize;
+    }
+    .component-content {
+      width: 100%;
+      height: 100%;
+    }
 
     .canvas-icon, .components-icon {
       position: fixed;
@@ -247,9 +263,15 @@
     if (!draggedHTML) return;
     const wrapper = document.createElement("div");
     wrapper.classList.add("canvas-component");
-    wrapper.innerHTML = draggedHTML;
-    wrapper.removeAttribute("draggable");
-    wrapper.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const content = document.createElement("div");
+    content.classList.add("component-content");
+    content.innerHTML = draggedHTML;
+    content.removeAttribute("draggable");
+    content.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const handle = document.createElement("div");
+    handle.classList.add("resize-handle");
+    wrapper.appendChild(content);
+    wrapper.appendChild(handle);
     wrapper.addEventListener('dragstart', e => e.preventDefault());
     wrapper.style.left = x + 'px';
     wrapper.style.top = y + 'px';
@@ -268,24 +290,26 @@
 
 
   function makeDraggable(el) {
+    const handle = el.querySelector('.resize-handle');
     let isDragging = false;
     let isResizing = false;
     let offsetX, offsetY;
     let startX, startY, startW, startH;
 
-    el.addEventListener("mousedown", function (e) {
-      const rect = el.getBoundingClientRect();
-      const nearRight = rect.right - e.clientX < 10;
-      const nearBottom = rect.bottom - e.clientY < 10;
-      if (nearRight || nearBottom) {
+    if (handle) {
+      handle.addEventListener('mousedown', function(e) {
         isResizing = true;
         startX = e.clientX;
         startY = e.clientY;
-        startW = rect.width;
-        startH = rect.height;
+        startW = el.offsetWidth;
+        startH = el.offsetHeight;
+        e.stopPropagation();
         e.preventDefault();
-        return;
-      }
+      });
+    }
+
+    el.addEventListener("mousedown", function (e) {
+      if (e.target === handle) return;
       isDragging = true;
       offsetX = e.clientX - el.offsetLeft;
       offsetY = e.clientY - el.offsetTop;
@@ -318,7 +342,8 @@
     const components = dropZone.querySelectorAll(".canvas-component");
     let content = "";
     components.forEach(el => {
-      const html = el.innerHTML;
+      const inner = el.querySelector('.component-content');
+      const html = inner ? inner.innerHTML : el.innerHTML;
       const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
       content += `<div ${style}>${html}</div>\n`;
     });

--- a/prime.html
+++ b/prime.html
@@ -90,8 +90,24 @@
       user-select: none;
       display: inline-block;
       box-sizing: border-box;
+      border: 1px dashed transparent;
     }
-
+    .canvas-component:hover {
+      border-color: #6c757d;
+    }
+    .resize-handle {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 10px;
+      height: 10px;
+      background: #007bff;
+      cursor: se-resize;
+    }
+    .component-content {
+      width: 100%;
+      height: 100%;
+    }
 
     .canvas-icon, .components-icon {
       position: fixed;
@@ -693,9 +709,15 @@
     if (!draggedHTML) return;
     const wrapper = document.createElement("div");
     wrapper.classList.add("canvas-component");
-    wrapper.innerHTML = draggedHTML;
-    wrapper.removeAttribute("draggable");
-    wrapper.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const content = document.createElement("div");
+    content.classList.add("component-content");
+    content.innerHTML = draggedHTML;
+    content.removeAttribute("draggable");
+    content.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const handle = document.createElement("div");
+    handle.classList.add("resize-handle");
+    wrapper.appendChild(content);
+    wrapper.appendChild(handle);
     wrapper.addEventListener('dragstart', e => e.preventDefault());
     wrapper.style.left = x + 'px';
     wrapper.style.top = y + 'px';
@@ -714,24 +736,26 @@
 
 
   function makeDraggable(el) {
+    const handle = el.querySelector('.resize-handle');
     let isDragging = false;
     let isResizing = false;
     let offsetX, offsetY;
     let startX, startY, startW, startH;
 
-    el.addEventListener("mousedown", function (e) {
-      const rect = el.getBoundingClientRect();
-      const nearRight = rect.right - e.clientX < 10;
-      const nearBottom = rect.bottom - e.clientY < 10;
-      if (nearRight || nearBottom) {
+    if (handle) {
+      handle.addEventListener('mousedown', function(e) {
         isResizing = true;
         startX = e.clientX;
         startY = e.clientY;
-        startW = rect.width;
-        startH = rect.height;
+        startW = el.offsetWidth;
+        startH = el.offsetHeight;
+        e.stopPropagation();
         e.preventDefault();
-        return;
-      }
+      });
+    }
+
+    el.addEventListener("mousedown", function (e) {
+      if (e.target === handle) return;
       isDragging = true;
       offsetX = e.clientX - el.offsetLeft;
       offsetY = e.clientY - el.offsetTop;
@@ -767,7 +791,8 @@
     let content = "";
 
     components.forEach(el => {
-      const html = el.innerHTML;
+      const inner = el.querySelector('.component-content');
+      const html = inner ? inner.innerHTML : el.innerHTML;
       const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
       content += `<div ${style}>${html}</div>\n`;
     });

--- a/tables.html
+++ b/tables.html
@@ -88,8 +88,24 @@
       user-select: none;
       display: inline-block;
       box-sizing: border-box;
+      border: 1px dashed transparent;
     }
-
+    .canvas-component:hover {
+      border-color: #6c757d;
+    }
+    .resize-handle {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 10px;
+      height: 10px;
+      background: #007bff;
+      cursor: se-resize;
+    }
+    .component-content {
+      width: 100%;
+      height: 100%;
+    }
 
     .canvas-icon, .components-icon {
       position: fixed;
@@ -279,9 +295,15 @@
     if (!draggedHTML) return;
     const wrapper = document.createElement("div");
     wrapper.classList.add("canvas-component");
-    wrapper.innerHTML = draggedHTML;
-    wrapper.removeAttribute("draggable");
-    wrapper.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const content = document.createElement("div");
+    content.classList.add("component-content");
+    content.innerHTML = draggedHTML;
+    content.removeAttribute("draggable");
+    content.querySelectorAll('[draggable]').forEach(el => el.removeAttribute('draggable'));
+    const handle = document.createElement("div");
+    handle.classList.add("resize-handle");
+    wrapper.appendChild(content);
+    wrapper.appendChild(handle);
     wrapper.addEventListener('dragstart', e => e.preventDefault());
     wrapper.style.left = x + 'px';
     wrapper.style.top = y + 'px';
@@ -300,24 +322,26 @@
 
 
   function makeDraggable(el) {
+    const handle = el.querySelector('.resize-handle');
     let isDragging = false;
     let isResizing = false;
     let offsetX, offsetY;
     let startX, startY, startW, startH;
 
-    el.addEventListener("mousedown", function (e) {
-      const rect = el.getBoundingClientRect();
-      const nearRight = rect.right - e.clientX < 10;
-      const nearBottom = rect.bottom - e.clientY < 10;
-      if (nearRight || nearBottom) {
+    if (handle) {
+      handle.addEventListener('mousedown', function(e) {
         isResizing = true;
         startX = e.clientX;
         startY = e.clientY;
-        startW = rect.width;
-        startH = rect.height;
+        startW = el.offsetWidth;
+        startH = el.offsetHeight;
+        e.stopPropagation();
         e.preventDefault();
-        return;
-      }
+      });
+    }
+
+    el.addEventListener("mousedown", function (e) {
+      if (e.target === handle) return;
       isDragging = true;
       offsetX = e.clientX - el.offsetLeft;
       offsetY = e.clientY - el.offsetTop;
@@ -350,7 +374,8 @@
     const components = dropZone.querySelectorAll(".canvas-component");
     let content = "";
     components.forEach(el => {
-      const html = el.innerHTML;
+      const inner = el.querySelector('.component-content');
+      const html = inner ? inner.innerHTML : el.innerHTML;
       const style = `style=\"position:absolute; left:${el.style.left}; top:${el.style.top}; width:${el.style.width}; height:${el.style.height};\"`;
       content += `<div ${style}>${html}</div>\n`;
     });


### PR DESCRIPTION
## Summary
- allow resizing of components placed on the preview canvas
- add resize handles and border styling
- exclude handles when exporting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c44a697cc83259107188faf768ae5